### PR TITLE
Document archive for July 2026 collection change

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,7 +54,7 @@ Budoucí automatizace má upravovat pouze datový soubor s jednorázovými změn
 
 * 2025-12-17 https://www.facebook.com/litovel.eu/posts/pfbid02mx6FiHsbQETRC2V9vzuCBQMpQUDh84tfzyz7NspBdy3AL5pMdApFuzaqmGLwSfphl, https://www.litovel.eu/cs/urad/uredni-deska/aktualni-informace/zmeny-svozu-odpadu-o-vanocnich-svatcich.html archiv https://web.archive.org/web/20251217074956/https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Flitovel.eu%2Fposts%2Fpfbid02mx6FiHsbQETRC2V9vzuCBQMpQUDh84tfzyz7NspBdy3AL5pMdApFuzaqmGLwSfphl a https://archive.is/Cuen5
 * 2026-02-12 https://www.litovel.eu/cs/urad/uredni-deska/aktualni-informace/zmena-svozu-odpadu.html, archiv https://archive.is/BOR4n
-* 2026-07-02 https://www.litovel.eu/cs/urad/uredni-deska/aktualni-informace/zmena-svozu-odpadu-v-pondeli-6-cervence.html
+* 2026-07-02 https://www.litovel.eu/cs/urad/uredni-deska/aktualni-informace/zmena-svozu-odpadu-v-pondeli-6-cervence.html, archiv https://web.archive.org/web/20260702141618/https://www.litovel.eu/cs/urad/uredni-deska/aktualni-informace/zmena-svozu-odpadu-v-pondeli-6-cervence.html
 
 .Archiv 2025
 [%collapsible]


### PR DESCRIPTION
Add the Wayback Machine snapshot for the Litovel notice covering the July 6 paper and BIO waste collection reschedules, preserving a stable source alongside the live municipal URL.